### PR TITLE
consistency in variable naming conventions

### DIFF
--- a/fabric_examples/basic_examples/create_slice.ipynb
+++ b/fabric_examples/basic_examples/create_slice.ipynb
@@ -107,17 +107,17 @@
    "source": [
     "from fabrictestbed.slice_editor import ExperimentTopology, Capacities, ComponentType, ComponentModelType, ServiceType\n",
     "# Create topology\n",
-    "myExperiment = ExperimentTopology()\n",
+    "experiment = ExperimentTopology()\n",
     "\n",
     "# Add node\n",
-    "myNode = myExperiment.add_node(name=node_name, site=site)\n",
+    "node = experiment.add_node(name=node_name, site=site)\n",
     "\n",
     "# Set capacities\n",
     "cap = Capacities()\n",
     "cap.set_fields(core=2, ram=16, disk=100)\n",
     "\n",
     "# Set Properties\n",
-    "myNode.set_properties(capacities=cap, image_type=image_type, image_ref=image_name)"
+    "node.set_properties(capacities=cap, image_type=image_type, image_ref=image_name)"
    ]
   },
   {
@@ -134,7 +134,7 @@
    "outputs": [],
    "source": [
     "# Generate Slice Graph\n",
-    "slice_graph = myExperiment.serialize()\n",
+    "slice_graph = experiment.serialize()\n",
     "\n",
     "# Request slice from Orchestrator\n",
     "return_status, slice_reservations = slice_manager.create(slice_name=slice_name, \n",
@@ -244,7 +244,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Initial fix for one of the example notebooks.
When a notebook uses a naming convention `firstSecond` changed to `first_second`.