### PR TITLE
Fixed Inconsistent Naming Convention

### DIFF
--- a/fabric_examples/basic_examples/create_node.ipynb
+++ b/fabric_examples/basic_examples/create_node.ipynb
@@ -113,17 +113,17 @@
    "source": [
     "from fabrictestbed.slice_editor import ExperimentTopology, Capacities, ComponentType, ComponentModelType, ServiceType\n",
     "# Create topology\n",
-    "myExperiment = ExperimentTopology()\n",
+    "experiment = ExperimentTopology()\n",
     "\n",
     "# Add node\n",
-    "myNode = myExperiment.add_node(name=node_name, site=site)\n",
+    "node = experiment.add_node(name=node_name, site=site)\n",
     "\n",
     "# Set capacities\n",
     "cap = Capacities()\n",
     "cap.set_fields(core=cores, ram=ram, disk=disk)\n",
     "\n",
     "# Set Properties\n",
-    "myNode.set_properties(capacities=cap, image_type=image_type, image_ref=image_name)"
+    "node.set_properties(capacities=cap, image_type=image_type, image_ref=image_name)"
    ]
   },
   {
@@ -142,7 +142,7 @@
    "outputs": [],
    "source": [
     "# Add PCI devices\n",
-    "nvme1 = myNode.add_component(ctype=ComponentType.NVME, model='P4510', name='nvme1')"
+    "nvme1 = node.add_component(ctype=ComponentType.NVME, model='P4510', name='nvme1')"
    ]
   },
   {
@@ -159,7 +159,7 @@
    "outputs": [],
    "source": [
     "# Generate Slice Graph\n",
-    "slice_graph = myExperiment.serialize()\n",
+    "slice_graph = experiment.serialize()\n",
     "\n",
     "# Request slice from Orchestrator\n",
     "return_status, slice_reservations = slice_manager.create(slice_name=slice_name, \n",
@@ -366,7 +366,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/fabric_examples/basic_examples/hello_fabric.ipynb
+++ b/fabric_examples/basic_examples/hello_fabric.ipynb
@@ -164,20 +164,20 @@
    "source": [
     "from fabrictestbed.slice_editor import ExperimentTopology, Capacities, ComponentType, ComponentModelType, ServiceType, Labels\n",
     "# Create topology\n",
-    "myExperiment = ExperimentTopology()\n",
+    "experiment = ExperimentTopology()\n",
     "\n",
     "# Add node\n",
-    "myNode = myExperiment.add_node(name=node_name, site=site)\n",
+    "node = experiment.add_node(name=node_name, site=site)\n",
     "\n",
     "# Set capacities\n",
     "cap = Capacities()\n",
     "cap.set_fields(core=cores, ram=ram, disk=disk)\n",
     "\n",
     "# Set Properties\n",
-    "myNode.set_properties(capacities=cap, image_type=image_type, image_ref=image)\n",
+    "node.set_properties(capacities=cap, image_type=image_type, image_ref=image)\n",
     "\n",
     "# Generate Slice Graph\n",
-    "slice_graph = myExperiment.serialize()\n",
+    "slice_graph = experiment.serialize()\n",
     "\n",
     "# Request slice from Orchestrator\n",
     "return_status, slice_reservations = slice_manager.create(slice_name=slice_name, slice_graph=slice_graph, ssh_key=ssh_key_pub)\n",
@@ -446,7 +446,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Some Jupyter notebooks in the `fabric_examples/basic_examples/` directory used the naming convention `firstSecond` when they should be using `first_second` as according to Python conventions and consistency with other notebooks.