### PR TITLE
Update renew_slice.ipynb

### DIFF
--- a/fabric_examples/fablib_api/renew_slice/renew_slice.ipynb
+++ b/fabric_examples/fablib_api/renew_slice/renew_slice.ipynb
@@ -75,7 +75,7 @@
     "import datetime\n",
     "\n",
     "#Set end host to now plus 1 day\n",
-    "end_date = (datetime.datetime.utcnow() + datetime.timedelta(days=6)).strftime(\"%Y-%m-%d %H:%M:%S\")\n",
+    "end_date = (datetime.datetime.utcnow() + datetime.timedelta(days=7)).astimezone().strftime(\"%Y-%m-%d %H:%M:%S %z\")\n",
     "\n",
     "try:\n",
     "    slice = fablib.get_slice(name=slice_name)\n",


### PR DESCRIPTION
The end_date string needs to include the time zone.

By the way, we can add a feature to fablib that adds an amount of time to the lease. It might be easier for the user. Like so:

    slice.extend_lease(days=7)

That would extend the lease by 7 days.

We can achieve this by encapsulating a similar line of code that generates an end date in a function. Pseudocode:

    def extend_lease(days):
        end_date = (datetime.datetime.strptime(slice1.get_lease_end(), "%Y-%m-%d %H:%M:%S %z") + datetime.timedelta(days=1)).astimezone().strftime("%Y-%m-%d %H:%M:%S %z")
        slice.renew(end_date)

We can also have something like below, but I'm not sure if it would be useful.

    slice.extend_lease(months=1, days=15, hours=12)