### PR TITLE
timestamp knit6 copier 

### DIFF
--- a/fabric_examples/mflib/KNIT6/KNIT6_mf_timestamp_standalone.ipynb
+++ b/fabric_examples/mflib/KNIT6/KNIT6_mf_timestamp_standalone.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "f6fe6684-3198-45d4-8854-4ed144bf6c49",
    "metadata": {},
@@ -45,11 +44,11 @@
    "metadata": {},
    "source": [
     "##### The node to run the timestamp service must have **docker**, **linuxptp** installed and configured.\n",
-    "##### For nodes on IPv6 sites, follow the instructions in this [fabric knowledge base article](https://learn.fabric-testbed.net/knowledge-base/using-ipv4-only-resources-like-github-or-docker-hub-from-ipv6-fabric-sites/) to access IPv4 resources(github and dockerhub)."
+    "##### For nodes on IPv6 sites, follow the instructions in this [fabric knowledge base article](https://learn.fabric-testbed.net/knowledge-base/using-ipv4-only-resources-like-github-or-docker-hub-from-ipv6-fabric-sites/) to access IPv4 resources(github and dockerhub).\n",
+    "##### Make sure there is no docker containers named timestamp or influxdb running on the nodes "
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "454e7947-0e60-4786-92a8-68d32a6ee561",
    "metadata": {},
@@ -77,9 +76,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "import importlib\n",
-    "\n",
     "from mflib.mf_timestamp import mf_timestamp "
    ]
   },
@@ -99,7 +95,7 @@
    "outputs": [],
    "source": [
     "# Change your slice name and node name(This is an example of a 3 node topology)\n",
-    "# set in common_imports slice_name=\"MyMonitoredSlice\"\n",
+    "# set in KNIT6_common_imports.ipynb slice_name=\"MyMonitoredSlice\"\n",
     "container_name=\"timestamp\"\n",
     "node1_name = 'Node1'\n",
     "node2_name = 'Node2'\n",
@@ -154,7 +150,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ptp_capable_sites=['STAR','MAX','MICH','MASS','UTAH','NCSA','UCSD','FIU','CLEM','CERN']\n",
+    "ptp_capable_sites=['STAR','MAX','MICH','MASS','UTAH','NCSA','UCSD','FIU','CLEM','CERN','INDI']\n",
     "nodes_on_ptp_sites=[]\n",
     "for node in slice.get_nodes():\n",
     "    site=node.get_site()\n",
@@ -357,8 +353,8 @@
     "except Exception as e:\n",
     "    print(f\"Fail: {e}\")\n",
     "user=\"rocky\"\n",
-    "fabric_ssh_config_path= \"{Your config file}\"\n",
-    "slice_key_path = \"{Your slice key}\"\n",
+    "fabric_ssh_config_path= \"{ssh config file}\"\n",
+    "slice_key_path = \"{slice key}\"\n",
     "print (f\"Node1 SSH command: ssh -F {fabric_ssh_config_path} -i {slice_key_path} {user}@{node1_management_ip}\")\n",
     "print (f\"Node2 SSH command: ssh -F {fabric_ssh_config_path} -i {slice_key_path} {user}@{node2_management_ip}\")"
    ]
@@ -889,8 +885,8 @@
     "local_port=\"10030\"\n",
     "influxdb_port=\"8086\"\n",
     "user = \"rocky\"\n",
-    "fabric_ssh_config_path= \"{Your config file}\"\n",
-    "slice_key_path = \"{Your slice key}\"\n",
+    "fabric_ssh_config_path= \"{ssh config file}\"\n",
+    "slice_key_path = \"{slice key}\"\n",
     "try:\n",
     "    node2_management_ip=node2.get_management_ip()\n",
     "except Exception as e:\n",

--- a/fabric_examples/mflib/KNIT6/KNIT6_mf_timestamp_with_mflib.ipynb
+++ b/fabric_examples/mflib/KNIT6/KNIT6_mf_timestamp_with_mflib.ipynb
@@ -1,10 +1,11 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "f6fe6684-3198-45d4-8854-4ed144bf6c49",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "# KNIT6\n",
     "# MF_Timestamp_Service(with measurement node in your slice)"
@@ -54,7 +55,20 @@
    "id": "988f9e2c-0438-432a-a2bc-24dcb1236d2b",
    "metadata": {},
    "source": [
-    "## Import"
+    "## Imports\n",
+    "This series of notebooks all need a common set of imports which are defined in [Common Imports](./KNIT6_common_imports.ipynb)\n",
+    "\n",
+    "**slice_name** is defined in this step. If you would like to change the slice_name, edit [Common Imports](./KNIT6_common_imports.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5e4b9600-2f17-4ad9-9d8b-09ea7c0d2d21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run \"./KNIT6_common_imports.ipynb\""
    ]
   },
   {
@@ -64,8 +78,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "import importlib\n",
     "from mflib.mf_timestamp import mf_timestamp "
    ]
   },
@@ -84,6 +96,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Change your slice name and node name(This is an example of a 3 node topology with meas_node)\n",
+    "# set in KNIT6_common_imports.ipynb slice_name=\"MyMonitoredSlice\"\n",
     "container_name=\"timestamp\"\n",
     "node1_name = 'Node1'\n",
     "node2_name = 'Node2'\n",
@@ -148,7 +162,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ptp_capable_sites=['STAR','MAX','MICH','MASS','UTAH','NCSA','UCSD','FIU','CLEM','CERN']\n",
+    "ptp_capable_sites=['STAR','MAX','MICH','MASS','UTAH','NCSA','UCSD','FIU','CLEM','CERN','INDI']\n",
     "nodes_on_ptp_sites=[]\n",
     "for node in slice.get_nodes():\n",
     "    site=node.get_site()\n",
@@ -388,10 +402,31 @@
     "except Exception as e:\n",
     "    print(f\"Fail: {e}\")\n",
     "user=\"rocky\"\n",
-    "fabric_ssh_config_path= \"{Your config file}\"\n",
-    "slice_key_path = \"{Your slice key}\"\n",
+    "fabric_ssh_config_path= \"{ssh config file}\"\n",
+    "slice_key_path = \"{slice key}\"\n",
     "print (f\"Node1 SSH command: ssh -F {fabric_ssh_config_path} -i {slice_key_path} {user}@{node1_management_ip}\")\n",
     "print (f\"Node2 SSH command: ssh -F {fabric_ssh_config_path} -i {slice_key_path} {user}@{node2_management_ip}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "387645aa-dc13-4361-b7bc-311b0531c1c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# find the ip address of an interface\n",
+    "# Specify the name of the experiment you set up on Node1\n",
+    "node1_network_name=\"net1\"\n",
+    "for iface in node1.get_interfaces():\n",
+    "    if (node1_network_name in iface.get_network().get_name()):\n",
+    "        node1_experiment_net_IP = iface.get_ip_addr()\n",
+    "        node1_physical_interface= iface.get_physical_os_interface_name()\n",
+    "iperf_server_cmd=\"sudo iperf3 -s\"\n",
+    "iperf_client_cmd=f\"sudo iperf3 -c {node1_experiment_net_IP} -t 10\"\n",
+    "print (f\"Go to your Node1 SSH terminal and run: {iperf_server_cmd}\")\n",
+    "print (f\"Go to your Node2 SSH terminal and run: {iperf_client_cmd}\")\n",
+    "print (f\"The interface name on Node1 is: {node1_physical_interface} (to be used in the cell below)\")"
    ]
   },
   {
@@ -411,7 +446,7 @@
    "source": [
     "# Check the interface ens/eth on that node and pass it as a parameter\n",
     "# Check the interface IP type to specify IP version\n",
-    "ts.record_packet_timestamp(node=node1_name,name=packet_test_name, interface=\"ens8\",ipversion=\"4\",\n",
+    "ts.record_packet_timestamp(node=node1_name,name=packet_test_name, interface=\"ens7\",ipversion=\"4\",\n",
     "                           protocol=\"tcp\", duration=\"10\", verbose=True)"
    ]
   },
@@ -900,8 +935,8 @@
     "local_port=\"10030\"\n",
     "influxdb_port=\"8086\"\n",
     "user = \"ubuntu\"\n",
-    "fabric_ssh_config_path= \"{Your config file}\"\n",
-    "slice_key_path = \"{Your slice key}\"\n",
+    "fabric_ssh_config_path= \"{ssh config file}\"\n",
+    "slice_key_path = \"{slice key}\"\n",
     "try:\n",
     "    meas_node_management_ip=meas_node.get_management_ip()\n",
     "except Exception as e:\n",


### PR DESCRIPTION
The ssh tunnel cmd gives the format as "-F ssh_config -i slice_key" instead of using specific locations to be consistent with KNIT6_elk_kibana.ipynb.