### PR TITLE
update notebooks for host names

### DIFF
--- a/fabric_examples/mflib/KNIT6/KNIT6_mf_timestamp_standalone.ipynb
+++ b/fabric_examples/mflib/KNIT6/KNIT6_mf_timestamp_standalone.ipynb
@@ -187,6 +187,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "751e6087-fe0f-4c23-b68b-20d5bf35e99d",
+   "metadata": {},
+   "source": [
+    "## Set host names of the nodes(temporary fix)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f746f8b-cb99-453d-a0f1-ce38cf9cfe5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmd = f\"sudo hostnamectl set-hostname `cat /var/lib/cloud/data/previous-hostname`\"\n",
+    "for node in [node1, node2, node3]:\n",
+    "    node.execute(cmd)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "228d06a1-02a6-4a1f-b9fc-21ded950af57",
    "metadata": {},
    "source": [
@@ -295,8 +315,8 @@
    "id": "4898f31a-d1da-47b7-95c6-39dc2aca42f6",
    "metadata": {},
    "source": [
-    "## Record timestamp for packets\n",
-    "### This method will trigger tcpdump to record packets and write to file"
+    "<font color=blue size=\"6\">*Timestamping Packets*</font>\n",
+    "### This method will first trigger tcpdump to record packets and then process the results"
    ]
   },
   {
@@ -494,7 +514,7 @@
    "id": "11163b26-c54e-4163-a065-7a85ae0544d1",
    "metadata": {},
    "source": [
-    "### Record timestamp for events"
+    "<font color=blue size=\"6\">*Timestamping Events*</font>"
    ]
   },
   {

--- a/fabric_examples/mflib/KNIT6/KNIT6_mf_timestamp_with_mflib.ipynb
+++ b/fabric_examples/mflib/KNIT6/KNIT6_mf_timestamp_with_mflib.ipynb
@@ -197,6 +197,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c2c75ac8-d7e3-4be9-984c-5ce080f66ab0",
+   "metadata": {},
+   "source": [
+    "## Set host names of the nodes(temporary fix)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c086e47a-5b7b-423a-8bef-72ae7e18e071",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmd = f\"sudo hostnamectl set-hostname `cat /var/lib/cloud/data/previous-hostname`\"\n",
+    "for node in [node1, node2, node3]:\n",
+    "    node.execute(cmd)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "228d06a1-02a6-4a1f-b9fc-21ded950af57",
    "metadata": {},
    "source": [
@@ -320,8 +340,8 @@
    "id": "4898f31a-d1da-47b7-95c6-39dc2aca42f6",
    "metadata": {},
    "source": [
-    "### Record timestamp for packets\n",
-    "#### This method will first trigger tcpdump to record packets and then process the results"
+    "<font color=blue size=\"6\">*Timestamping Packets*</font>\n",
+    "### This method will first trigger tcpdump to record packets and then process the results"
    ]
   },
   {
@@ -402,8 +422,8 @@
     "except Exception as e:\n",
     "    print(f\"Fail: {e}\")\n",
     "user=\"rocky\"\n",
-    "fabric_ssh_config_path= \"{ssh config file}\"\n",
-    "slice_key_path = \"{slice key}\"\n",
+    "fabric_ssh_config_path= \"ssh_config\"\n",
+    "slice_key_path = \"slice_key\"\n",
     "print (f\"Go to the dir where you untar 'fabric_ssh_tunnel_tools.gz' and run the cmd to ssh into Node1\")\n",
     "print (f\"ssh -F {fabric_ssh_config_path} -i {slice_key_path} {user}@{node1_management_ip}\")\n",
     "print (f\"Go to the dir where you untar 'fabric_ssh_tunnel_tools.gz' and run the cmd to ssh into Node2\")\n",
@@ -448,7 +468,7 @@
    "source": [
     "# Check the interface ens/eth on that node and pass it as a parameter\n",
     "# Check the interface IP type to specify IP version\n",
-    "ts.record_packet_timestamp(node=node1_name,name=packet_test_name, interface=\"ens8\",ipversion=\"4\",\n",
+    "ts.record_packet_timestamp(node=node1_name,name=packet_test_name, interface=\"ens7\",ipversion=\"4\",\n",
     "                           protocol=\"tcp\", duration=\"10\", verbose=True)"
    ]
   },
@@ -541,7 +561,7 @@
    "id": "11163b26-c54e-4163-a065-7a85ae0544d1",
    "metadata": {},
    "source": [
-    "### Record timestamp for events"
+    "<font color=blue size=\"6\">*Timestamping Events*</font>"
    ]
   },
   {
@@ -1125,7 +1145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c50fa173-2d28-41f9-8a10-9f49c0899c34",
+   "id": "4a7eec92-d4a2-4469-a0f7-f129b7a95ee5",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Temporary uses hostnamectl set-hostname to set hostnames back to the format with id