### PR TITLE
Added example of adding extra SSH keys 

### DIFF
--- a/fabric_examples/fablib_api/other_ssh_keys/add_keys_into_slice.ipynb
+++ b/fabric_examples/fablib_api/other_ssh_keys/add_keys_into_slice.ipynb
@@ -1,0 +1,187 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Adding other users' SSH keys into the slice\n",
+    "\n",
+    "This Jupyter notebook will walk you through creating a simple slice, very similar to Hello FABRIC example, and demonstrate how other users' keys can be added either before the slice is created, or after via a POA (Perform Operational Action) call.\n",
+    "\n",
+    "## Step 1:  Configure the Environment\n",
+    "\n",
+    "Before running this notebook, you will need to configure your environment using the [Configure Environment](../../../configure.ipynb) notebook. Please stop here, open and run that notebook, then return to this notebook.\n",
+    "\n",
+    "If you are using the FABRIC JupyterHub many of the environment variables will be automatically configured for you.  You will still need to set your bastion username, upload your bastion private key, and set the path to where you put your bastion private key. Your bastion username and private key should already be in your possession.  \n",
+    "\n",
+    "If you are using the FABRIC API outside of the JupyterHub you will need to configure all of the environment variables. Defaults below will be correct in many situations but you will need to confirm your configuration.  If you have questions about this configuration, please contact the FABRIC admins using the [FABRIC User Forum](https://learn.fabric-testbed.net/forums/) \n",
+    "\n",
+    "More information about accessing your experiments through the FABRIC bastion hosts can be found [here](https://learn.fabric-testbed.net/knowledge-base/logging-into-fabric-vms/).\n",
+    " "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Step 2: Import the FABlib Library"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from fabrictestbed_extensions.fablib.fablib import FablibManager as fablib_manager\n",
+    "\n",
+    "fablib = fablib_manager()\n",
+    "\n",
+    "fablib.show_config();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Step 3: Create the Experiment Slice\n",
+    "\n",
+    "The following creates a single node with basic compute capabilities. In addition to your public key it also adds two other keys (shown here by example - __do not use these keys in real experiments__). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Create a slice\n",
+    "slice = fablib.new_slice(name=\"MySlice with extra SSH keys\")\n",
+    "\n",
+    "# Add a node\n",
+    "node = slice.add_node(name=\"Node1\")\n",
+    "\n",
+    "# Submit the slice by providing two extra keys\n",
+    "extra_ssh_keys=['ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBI1scIhcI0VLxiTZlI4Zt1rxUFfU3nISDZhDm2fk4CZbdMAsOec/5Oq2UjN7yu7hibsVprysMMPoxXc7OfjQfXk= userkey1',\n",
+    "                'ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBH+0ua+cFUwR23rcuTRHB7IpbSof5c3qQuQlKb6vaEgqLuNe+9EM7nJKwQVJqr2glSN+qZeXfXSRqkcqLQLZ4uA= userkey2']\n",
+    "# keys are added by using an optional named parameter 'extra_ssh_keys'\n",
+    "slice.submit(extra_ssh_keys=extra_ssh_keys);\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: Observe the Slice's Attributes\n",
+    "\n",
+    "### Show the slice attributes "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "slice.show();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Step 5: Show the keys are present in the VM\n",
+    "\n",
+    "Here we demonstrate the keys were properly installed. You should see them in the output of the following command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "node = slice.get_node('Node1')\n",
+    " \n",
+    "command = 'cat .ssh/authorized_keys'\n",
+    "\n",
+    "stdout, stderr = node.execute(command)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 6: Add another key via POA\n",
+    "\n",
+    "This is work in progress."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Step 7: Delete the Slice\n",
+    "\n",
+    "Please delete your slice when you are done with your experiment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "slice.delete()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/start_here.ipynb
+++ b/start_here.ipynb
@@ -87,6 +87,7 @@
     "## Experiment Configuration\n",
     "\n",
     "- Manual Tasks\n",
+    "    - [Adding other users' keys into slice](./fabric_examples/fablib_api/other_ssh_keys/add_keys_into_slice.ipynb): Add new keys on submit or add later via POA (Perform Operational Action)\n",
     "    - [Upload and Execute Scripts](./fabric_examples/fablib_api/upload_and_execute/upload_and_execute.ipynb): Upload a script and execute it.\n",
     "    - [Accessing IPv4 Sites from IPv6 Nodes](./fabric_examples/fablib_api/accessing_ipv4_services_from_ipv6_nodes/accessing_ipv4_services_from_ipv6_nodes.ipynb): Access non-IPv6 services (i.e. GitHub) from IPv6 FABRIC nodes.   \n",
     "    - [Parallel Experiment Configuration](./fabric_examples/fablib_api/parallel_config/parallel_config.ipynb): Use threads to configure experiments in parallel.\n",


### PR DESCRIPTION
that is possible with fablib 1.5.2 and above. Related to fabric-testbed/fabrictestbed-extensions#211 