### PR TITLE
Updated acceptance test and GPU notebook to not use custom Nat64 and Ubuntu22 image with CUDA

### DIFF
--- a/fabric_examples/acceptance_testing/Acceptance Tests 3.1.2/functional_test_3.1.2-gpu.ipynb
+++ b/fabric_examples/acceptance_testing/Acceptance Tests 3.1.2/functional_test_3.1.2-gpu.ipynb
@@ -84,7 +84,7 @@
     "site='CERN'\n",
     "# since all workers have a standard naming scheme, you can just change the worker\n",
     "# to move from worker to worker\n",
-    "worker=f'{site.lower()}-w2.fabric-testbed.net'\n",
+    "worker=f'{site.lower()}-w6.fabric-testbed.net'\n",
     "cores=10\n",
     "ram=20\n",
     "disk=50\n",
@@ -103,7 +103,7 @@
     "    slice = fablib.new_slice(name=slice_name)\n",
     "\n",
     "    # Add node\n",
-    "    node = slice.add_node(name=name, site=site, host=worker, cores=cores, ram=ram, disk=disk)\n",
+    "    node = slice.add_node(name=name, site=site, host=worker, cores=cores, ram=ram, disk=disk, image='default_ubuntu_22')\n",
     "    \n",
     "    # Add a GPU by type - be sure to select the righ kind for that worker\n",
     "    # you can also add multiple GPUs at once if the node has several by\n",
@@ -185,12 +185,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "command = \"sudo dnf install -q -y pciutils && lspci | grep 'NVIDIA\\|3D controller'\"\n",
-    "try:\n",
-    "    stdout, stderr = node.execute(command)\n",
-    "    print(f\"stdout: {stdout}\")\n",
-    "except Exception as e:\n",
-    "    print(f\"Exception: {e}\")"
+    "command = \"sudo apt-get install -y pciutils && lspci | grep 'NVIDIA\\|3D controller'\"\n",
+    "\n",
+    "stdout, stderr = node.execute(command)"
    ]
   },
   {
@@ -206,35 +203,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*If the site has IPv6 management address*, run the following cell to set up NAT64, otherwise **skip to installing drivers.**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from ipaddress import ip_address, IPv6Address\n",
-    "\n",
-    "nat64script = '../../fablib_api/accessing_ipv4_services_from_ipv6_nodes/nat64.sh'\n",
-    "try:\n",
-    "    node = slice.get_node(name=\"Node1\")     \n",
-    "    \n",
-    "    # If the node is an IPv6 Node then configure NAT64. We use the\n",
-    "    # same script as 'Accessing IPv4 services from IPv6' notebook.\n",
-    "    if type(ip_address(node.get_management_ip())) is IPv6Address:\n",
-    "        node.upload_file(nat64script, 'nat64.sh')\n",
-    "        \n",
-    "        stdout, stderr = node.execute(f'chmod +x nat64.sh && ./nat64.sh')\n",
-    "except Exception as e:\n",
-    "    print(f\"Exception: {e}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Now install NVIDIA drivers (may take a long time, be prepared to wait)."
    ]
   },
@@ -244,18 +212,34 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "distro='ubuntu2204'\n",
+    "version='12.2'\n",
+    "architecture='x86_64'\n",
+    "\n",
+    "# install prerequisites\n",
     "commands = [\n",
-    "    'sudo dnf install -q -y epel-release',\n",
-    "    'sudo dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo',\n",
-    "    'sudo dnf install -q -y kernel-devel kernel-headers nvidia-driver nvidia-settings cuda-driver cuda'\n",
+    "    'sudo apt-get -q update',\n",
+    "    'sudo apt-get -q install -y linux-headers-$(uname -r) gcc',\n",
     "]\n",
-    "try:\n",
-    "    print(\"Installing CUDA...\")\n",
-    "    for command in commands:\n",
-    "        stdout, stderr = node.execute(command)\n",
-    "    print(\"Done installing CUDA. Now, reboot for the changes to take effect.\")\n",
-    "except Exception as e:\n",
-    "    print(f\"Fail: {e}\")"
+    "\n",
+    "print(\"Installing Prerequisites...\")\n",
+    "for command in commands:\n",
+    "    print(f\"++++ {command}\")\n",
+    "    stdout, stderr = node.execute(command)\n",
+    "\n",
+    "print(f\"Installing CUDA {version}\")\n",
+    "commands = [\n",
+    "    f'wget https://developer.download.nvidia.com/compute/cuda/repos/{distro}/{architecture}/cuda-keyring_1.1-1_all.deb',\n",
+    "    f'sudo dpkg -i cuda-keyring_1.1-1_all.deb',\n",
+    "    'sudo apt-get -q update',\n",
+    "    'sudo apt-get -q install -y cuda'\n",
+    "]\n",
+    "print(\"Installing CUDA...\")\n",
+    "for command in commands:\n",
+    "    print(f\"++++ {command}\")\n",
+    "    stdout, stderr = node.execute(command)\n",
+    "    \n",
+    "print(\"Done installing CUDA\")"
    ]
   },
   {
@@ -353,7 +337,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/fabric_examples/fablib_api/fabric_all_gpus/fabric_gpu.ipynb
+++ b/fabric_examples/fablib_api/fabric_all_gpus/fabric_gpu.ipynb
@@ -59,7 +59,7 @@
     "# GPU_TeslaT4\n",
     "# GPU_A30\n",
     "# GPU_A40\n",
-    "GPU_CHOICE = 'GPU_A40' \n",
+    "GPU_CHOICE = 'GPU_RTX6000' \n",
     "\n",
     "# don't edit - convert from GPU type to a resource column name\n",
     "# to use in filter lambda function below\n",
@@ -108,7 +108,12 @@
    "outputs": [],
    "source": [
     "# find a site with at least one available GPU of the selected type\n",
-    "site = fablib.get_random_site(filter_function=lambda x: x[column_name] > 0)\n",
+    "site_override = None\n",
+    "\n",
+    "if site_override:\n",
+    "    site = site_override\n",
+    "else:\n",
+    "    site = fablib.get_random_site(filter_function=lambda x: x[column_name] > 0)\n",
     "print(f'Preparing to create slice \"{slice_name}\" with node {node_name} in site {site}')"
    ]
   },
@@ -130,7 +135,7 @@
     "slice = fablib.new_slice(name=slice_name)\n",
     "\n",
     "# Add node with a 100G drive and a couple of CPU cores (default)\n",
-    "node = slice.add_node(name=node_name, site=site, disk=100)\n",
+    "node = slice.add_node(name=node_name, site=site, disk=100, image='default_ubuntu_22')\n",
     "node.add_component(model=GPU_CHOICE, name='gpu1')\n",
     "\n",
     "#Submit Slice Request\n",
@@ -182,103 +187,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Deal with IPv6 sites"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Most of FABRIC sites provide IPv6 management interfaces and there are a number of prominent resources on the internet, chiefly GitHub and NVidia website that are not present on IPv6. To deal with it we need to check the type of management IP address our GPU node received and if it is an IPv6 address, configure its DNS so it can reach IPv4 networks."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from ipaddress import ip_address, IPv6Address    \n",
-    "\n",
-    "isipv6_site = False\n",
-    "# If the node is an IPv6 Node then configure NAT64\n",
-    "if type(ip_address(node.get_management_ip())) is IPv6Address:\n",
-    "    isipv6_site = True\n",
-    "    print(f'Node {node.get_name()} has an IPv6 management address, will update DNS configuration')\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# this code will be executed if the node uses an IPv6 site. See the notebook \n",
-    "# 'Access non-IPv6 services (i.e. GitHub) from IPv6 FABRIC nodes' for more details\n",
-    "\n",
-    "if isipv6_site:\n",
-    "    node.upload_file('../accessing_ipv4_services_from_ipv6_nodes/nat64.sh', 'nat64.sh')\n",
-    "    stdout, stderr = node.execute(f'chmod +x nat64.sh && ./nat64.sh')\n",
-    "    print(f'Uploaded and executed NAT64 DNS setup script to node {node.get_name()}')\n",
-    "    "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "## Update the Node"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Next we should update the Rocky (default) distribution with latest packages to ensure NVidia install process works as expected."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "command = \"sudo dnf upgrade -q -y\"\n",
-    "stdout, stderr = node.execute(command)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Don't forget to reboot so the update changes take effect"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "reboot = 'sudo reboot'\n",
-    "\n",
-    "print(reboot)\n",
-    "node.execute(reboot)\n",
-    "\n",
-    "slice.wait_ssh(timeout=360,interval=10,progress=True)\n",
-    "\n",
-    "print(\"Now testing SSH abilites to reconnect...\",end=\"\")\n",
-    "slice.update()\n",
-    "slice.test_ssh()\n",
-    "print(\"Reconnected!\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## GPU PCI Device\n",
     "\n",
     "Run the command <code>lspci</code> to see your GPU PCI device(s). This is the raw GPU PCI device that is not yet configured for use.  You can use the GPUs as you would any GPUs.\n",
@@ -292,7 +200,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "command = \"sudo dnf install -q -y pciutils && lspci | grep 'NVIDIA\\|3D controller'\"\n",
+    "command = \"sudo apt-get install -y pciutils && lspci | grep 'NVIDIA\\|3D controller'\"\n",
     "\n",
     "stdout, stderr = node.execute(command)"
    ]
@@ -303,7 +211,9 @@
    "source": [
     "## Install Nvidia Drivers\n",
     "\n",
-    "Now, let's run the following commands to install the latest NVidia driver and the CUDA libraries and compiler."
+    "Now, let's run the following commands to install the latest NVidia driver and the CUDA libraries and compiler. This step can take up to 20 minutes.\n",
+    "\n",
+    "NOTE: for instructional purposes the following cell sends all command output back to the notebook. You can also send it to log files to keep the notebook output clean."
    ]
   },
   {
@@ -312,19 +222,34 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# source: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html#rhel-8-rocky-8\n",
+    "distro='ubuntu2204'\n",
+    "version='12.2'\n",
+    "architecture='x86_64'\n",
+    "\n",
+    "# install prerequisites\n",
     "commands = [\n",
-    "    'sudo dnf install -q -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm',\n",
-    "    'sudo dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo',\n",
-    "    'sudo dnf clean expire-cache',\n",
-    "    'sudo dnf module install -q -y nvidia-driver:latest-dkms',\n",
-    "    'sudo dnf install -q -y cuda'\n",
+    "    'sudo apt-get -q update',\n",
+    "    'sudo apt-get -q install -y linux-headers-$(uname -r) gcc',\n",
     "]\n",
     "\n",
+    "print(\"Installing Prerequisites...\")\n",
+    "for command in commands:\n",
+    "    print(f\"++++ {command}\")\n",
+    "    stdout, stderr = node.execute(command)\n",
+    "\n",
+    "print(f\"Installing CUDA {version}\")\n",
+    "commands = [\n",
+    "    f'wget https://developer.download.nvidia.com/compute/cuda/repos/{distro}/{architecture}/cuda-keyring_1.1-1_all.deb',\n",
+    "    f'sudo dpkg -i cuda-keyring_1.1-1_all.deb',\n",
+    "    'sudo apt-get -q update',\n",
+    "    'sudo apt-get -q install -y cuda'\n",
+    "]\n",
     "print(\"Installing CUDA...\")\n",
     "for command in commands:\n",
+    "    print(f\"++++ {command}\")\n",
     "    stdout, stderr = node.execute(command)\n",
-    "print(\"Done installing CUDA. Now, reboot for the changes to take effect.\")"
+    "    \n",
+    "print(\"Done installing CUDA\")"
    ]
   },
   {
@@ -410,7 +335,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stdout, stderr = node.execute(\"/usr/local/cuda-12.1/bin/nvcc -o hello_world hello-world.cu\")"
+    "stdout, stderr = node.execute(f\"/usr/local/cuda-{version}/bin/nvcc -o hello_world hello-world.cu\")"
    ]
   },
   {
@@ -457,6 +382,13 @@
    "source": [
     "fablib.delete_slice(slice_name)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -475,7 +407,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Nat64 script installation has been removed
- Image update and package management updated for Ubuntu 22

I gave up on making Rocky8 work - it's too old and cranky.

We should merge this as soon as we can so acceptance testing team can start using it on new sites. 