### PR TITLE
Added examples on how to filter by PTP, 

### DIFF
--- a/fabric_examples/fablib_api/sites_and_resources/filter_sites_by_available_resources.ipynb
+++ b/fabric_examples/fablib_api/sites_and_resources/filter_sites_by_available_resources.ipynb
@@ -98,11 +98,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Get sites with native PTP capability"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fablib.list_sites(filter_function=lambda x: x['ptp_capable'] is True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Get a Site with Available Resources\n",
     "\n",
     "Often you want to find a site that has the resources to support a VM with specific attributes. FABlib provides this functionality by accepting a `filter_function` in the `fablib.get_random_sites` method.   \n",
     "\n",
-    "The example below, finds two sites that have at least one available ConnectX-6 cards with one in eastern U.S. and the other in the west.\n"
+    "The example below, finds two sites that have at least one available ConnectX-6 cards with one in eastern U.S. and the other in the west, both with support for PTP.\n",
+    "\n",
+    "Note that because the filter is looking for *available* ConnectX-6 cards and there may not be any at this moment, the code may not return a site for either query.\n"
    ]
   },
   {
@@ -113,8 +131,8 @@
    "source": [
     "st_louis_lat_long=(32.773081, -96.797448)\n",
     "\n",
-    "west_site = fablib.get_random_site(filter_function=lambda x: x['nic_connectx_6_available'] > 0 and x['location'][1] < st_louis_lat_long[1])                                                                                                                                                                                                                           \n",
-    "east_site = fablib.get_random_site(filter_function=lambda x: x['nic_connectx_6_available'] > 0 and x['location'][1] > st_louis_lat_long[1])                                                                                                                                                                                                                           \n",
+    "west_site = fablib.get_random_site(filter_function=lambda x: x['nic_connectx_6_available'] > 0 and x['location'][1] < st_louis_lat_long[1] and x['ptp_capable'] is True)                                                                                                                                                                                                                           \n",
+    "east_site = fablib.get_random_site(filter_function=lambda x: x['nic_connectx_6_available'] > 0 and x['location'][1] > st_louis_lat_long[1] and x['ptp_capable'] is True)                                                                                                                                                                                                                           \n",
     "\n",
     "print(f\"west_site: {west_site}\")\n",
     "print(f\"east_site: {east_site}\")"
@@ -164,7 +182,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/fabric_examples/fablib_api/sites_and_resources/list_all_resources.ipynb
+++ b/fabric_examples/fablib_api/sites_and_resources/list_all_resources.ipynb
@@ -55,7 +55,11 @@
    },
    "outputs": [],
    "source": [
-    "output_table = fablib.list_sites()"
+    "# setting latlon to False greatly speeds up the return process, but you do not get the latitude and longitude of the sites\n",
+    "# the API default is a True, but here we can override it\n",
+    "latlon=False\n",
+    "\n",
+    "output_table = fablib.list_sites(latlon=latlon)"
    ]
   },
   {
@@ -71,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "output_table = fablib.list_sites(pretty_names=False)"
+    "output_table = fablib.list_sites(pretty_names=False, latlon=latlon)"
    ]
   },
   {
@@ -100,7 +104,7 @@
    },
    "outputs": [],
    "source": [
-    "output_table = fablib.list_sites(fields=fields)"
+    "output_table = fablib.list_sites(fields=fields, latlon=latlon)"
    ]
   },
   {
@@ -120,7 +124,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "output_table = fablib.list_sites(output='pandas',fields=fields)"
+    "output_table = fablib.list_sites(output='pandas',fields=fields, latlon=latlon)"
    ]
   },
   {
@@ -139,7 +143,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "output_table = fablib.list_sites(output='text',fields=fields)"
+    "output_table = fablib.list_sites(output='text',fields=fields, latlon=latlon)"
    ]
   },
   {
@@ -159,7 +163,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "output_json = fablib.list_sites(output='json')"
+    "output_json = fablib.list_sites(output='json', latlon=latlon)"
    ]
   },
   {
@@ -179,7 +183,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "output_list = fablib.list_sites(output='list')"
+    "output_list = fablib.list_sites(output='list', latlon=latlon)"
    ]
   },
   {
@@ -195,7 +199,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "output_list = fablib.list_sites(output='list', quiet=True)\n",
+    "output_list = fablib.list_sites(output='list', quiet=True, latlon=latlon)\n",
     "\n",
     "for site in output_list:\n",
     "    print(f\"Site: {site['name']}, {site['cores_available']}, {site['ram_available']}, {site['disk_available']}, {site['nic_basic_available']}\")"
@@ -245,7 +249,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
depends on fablib version 1.5.5 and above (fabric-testbed/fabrictestbed-extensions#236) 