### PR TITLE
Update fabric_gpu.ipynb to install specified cuda version

### DIFF
--- a/fabric_examples/fablib_api/fabric_all_gpus/fabric_gpu.ipynb
+++ b/fabric_examples/fablib_api/fabric_all_gpus/fabric_gpu.ipynb
@@ -254,7 +254,7 @@
     "    f'wget https://developer.download.nvidia.com/compute/cuda/repos/{distro}/{architecture}/cuda-keyring_1.1-1_all.deb',\n",
     "    f'sudo dpkg -i cuda-keyring_1.1-1_all.deb',\n",
     "    'sudo apt-get -q update',\n",
-    "    'sudo apt-get -q install -y cuda'\n",
+    "    'sudo apt-get -q install -y cuda-{version.replace(\".\", \"-\")}'\n",
     "]\n",
     "print(\"Installing CUDA...\")\n",
     "for command in commands:\n",


### PR DESCRIPTION
Current steps installs latest cuda packages and will be broken from time to time, force apt to install the intended version defined by the user