### PR TITLE
Use get_random_sites instead of hardcoded sites in CephFS notebooks

### DIFF
--- a/fabric_examples/fablib_api/cephfs_storage/cephfs_storage.ipynb
+++ b/fabric_examples/fablib_api/cephfs_storage/cephfs_storage.ipynb
@@ -32,13 +32,13 @@
    "id": "cell-4",
    "metadata": {},
    "outputs": [],
-   "source": "import json\n\nclusters = fablib.discover_ceph_clusters()\nprint(f\"Available storage clusters: {json.dumps(clusters, indent=2)}\")"
+   "source": "import json\n\nclusters = fablib.discover_ceph_clusters()\nprint(f\"Available storage clusters: {json.dumps(clusters, indent=2)}\")\n\nuser_clusters = fablib.discover_user_ceph_clusters()\nprint(f\"\\nClusters with your credentials: {json.dumps(user_clusters, indent=2)}\")"
   },
   {
    "cell_type": "markdown",
    "id": "cell-5",
    "metadata": {},
-   "source": "---\n## Demo 1: Multi-Site Data Sharing\n\nThis demo creates two nodes at **different FABRIC sites** (MAX and UTAH). Both nodes mount the same distributed shared filesystem. Data written at one site is instantly visible at the other — no manual file transfer needed.\n\nThis is the simplest usage: pass `storage=True` to `new_slice()` and every node gets shared storage automatically."
+   "source": "---\n## Demo 1: Multi-Site Data Sharing\n\nThis demo creates two nodes at **different FABRIC sites** (randomly selected). Both nodes mount the same distributed shared filesystem. Data written at one site is instantly visible at the other — no manual file transfer needed.\n\nThis is the simplest usage: pass `storage=True` to `new_slice()` and every node gets shared storage automatically."
   },
   {
    "cell_type": "code",
@@ -46,7 +46,7 @@
    "id": "cell-6",
    "metadata": {},
    "outputs": [],
-   "source": "# Create a slice with storage enabled on ALL nodes\nslice1 = fablib.new_slice(name=\"CephFS-MultiSite\", storage=True)\n\nmax_node = slice1.add_node(name=\"max-node\", site=\"MAX\", cores=4, ram=8, disk=50)\nutah_node = slice1.add_node(name=\"utah-node\", site=\"UTAH\", cores=4, ram=8, disk=50)\n\nslice1.submit();"
+   "source": "# Pick two random sites for multi-site demo\n[site1, site2] = fablib.get_random_sites(count=2)\nprint(f\"Using sites: {site1}, {site2}\")\n\n# Create a slice with storage enabled on ALL nodes\nslice1 = fablib.new_slice(name=\"CephFS-MultiSite\", storage=True)\n\nnode_a = slice1.add_node(name=\"site-a-node\", site=site1, cores=4, ram=8, disk=50)\nnode_b = slice1.add_node(name=\"site-b-node\", site=site2, cores=4, ram=8, disk=50)\n\nslice1.submit();"
   },
   {
    "cell_type": "markdown",
@@ -66,7 +66,7 @@
    "cell_type": "markdown",
    "id": "cell-9",
    "metadata": {},
-   "source": "### Write at MAX, read at UTAH\n\nData written to shared storage at one site is instantly available at the other. This is the key benefit of distributed storage — no `scp`, no `rsync`, no coordination needed."
+   "source": "### Write at Site A, read at Site B\n\nData written to shared storage at one site is instantly available at the other. This is the key benefit of distributed storage — no `scp`, no `rsync`, no coordination needed."
   },
   {
    "cell_type": "code",
@@ -74,13 +74,13 @@
    "id": "cell-10",
    "metadata": {},
    "outputs": [],
-   "source": "max_node = slice1.get_node(\"max-node\")\nutah_node = slice1.get_node(\"utah-node\")\n\n# Discover the shared storage mount path\nstdout, _ = max_node.execute(\"mount | grep ceph | awk '{print $3}' | head -1\", quiet=True)\nmount_path = stdout.strip()\nprint(f\"Shared storage mount path: {mount_path}\")\n\n# Write a dataset at MAX\nprint(\"\\n--- Writing at MAX ---\")\nmax_node.execute(f\"mkdir -p {mount_path}/demo1\")\nmax_node.execute(f\"echo 'Experiment results from MAX site' > {mount_path}/demo1/results.txt\")\nmax_node.execute(f\"date >> {mount_path}/demo1/results.txt\")\nstdout, _ = max_node.execute(f\"cat {mount_path}/demo1/results.txt\")\n\n# Read the same data at UTAH — no copy needed!\nprint(\"--- Reading at UTAH (same data, no transfer!) ---\")\nstdout, _ = utah_node.execute(f\"cat {mount_path}/demo1/results.txt\")\n\n# Write back from UTAH\nprint(\"--- UTAH appends to the shared file ---\")\nutah_node.execute(f\"echo 'Analysis completed at UTAH site' >> {mount_path}/demo1/results.txt\")\n\n# Verify at MAX\nprint(\"--- MAX sees UTAH's update ---\")\nstdout, _ = max_node.execute(f\"cat {mount_path}/demo1/results.txt\")"
+   "source": "node_a = slice1.get_node(\"site-a-node\")\nnode_b = slice1.get_node(\"site-b-node\")\n\n# Discover the shared storage mount path\nstdout, _ = node_a.execute(\"mount | grep ceph | awk '{print $3}' | head -1\", quiet=True)\nmount_path = stdout.strip()\nprint(f\"Shared storage mount path: {mount_path}\")\n\n# Write a dataset at Site A\nprint(f\"\\n--- Writing at {node_a.get_site()} ---\")\nnode_a.execute(f\"mkdir -p {mount_path}/demo1\")\nnode_a.execute(f\"echo 'Experiment results from {node_a.get_site()}' > {mount_path}/demo1/results.txt\")\nnode_a.execute(f\"date >> {mount_path}/demo1/results.txt\")\nstdout, _ = node_a.execute(f\"cat {mount_path}/demo1/results.txt\")\n\n# Read the same data at Site B — no copy needed!\nprint(f\"--- Reading at {node_b.get_site()} (same data, no transfer!) ---\")\nstdout, _ = node_b.execute(f\"cat {mount_path}/demo1/results.txt\")\n\n# Write back from Site B\nprint(f\"--- {node_b.get_site()} appends to the shared file ---\")\nnode_b.execute(f\"echo 'Analysis completed at {node_b.get_site()}' >> {mount_path}/demo1/results.txt\")\n\n# Verify at Site A\nprint(f\"--- {node_a.get_site()} sees the update ---\")\nstdout, _ = node_a.execute(f\"cat {mount_path}/demo1/results.txt\")"
   },
   {
    "cell_type": "markdown",
    "id": "cell-11",
    "metadata": {},
-   "source": "### Measure cross-site throughput\n\nWrite a larger file at MAX and measure how quickly UTAH can read it through shared storage."
+   "source": "### Measure cross-site throughput\n\nWrite a larger file at Site A and measure how quickly Site B can read it through shared storage."
   },
   {
    "cell_type": "code",
@@ -88,7 +88,7 @@
    "id": "cell-12",
    "metadata": {},
    "outputs": [],
-   "source": "# Write a 256MB file at MAX\nprint(\"--- MAX: Writing 256MB test file ---\")\nmax_node.execute(f\"dd if=/dev/urandom of={mount_path}/demo1/testfile_256m bs=1M count=256 status=progress\")\n\n# Read it at UTAH and measure throughput\nprint(\"\\n--- UTAH: Reading 256MB file from CephFS ---\")\nutah_node.execute(f\"dd if={mount_path}/demo1/testfile_256m of=/dev/null bs=1M status=progress\")\n\n# Clean up the test file\nmax_node.execute(f\"rm -f {mount_path}/demo1/testfile_256m\", quiet=True)"
+   "source": "# Write a 256MB file at Site A\nprint(f\"--- {node_a.get_site()}: Writing 256MB test file ---\")\nnode_a.execute(f\"dd if=/dev/urandom of={mount_path}/demo1/testfile_256m bs=1M count=256 status=progress\")\n\n# Read it at Site B and measure throughput\nprint(f\"\\n--- {node_b.get_site()}: Reading 256MB file from CephFS ---\")\nnode_b.execute(f\"dd if={mount_path}/demo1/testfile_256m of=/dev/null bs=1M status=progress\")\n\n# Clean up the test file\nnode_a.execute(f\"rm -f {mount_path}/demo1/testfile_256m\", quiet=True)"
   },
   {
    "cell_type": "markdown",
@@ -102,7 +102,7 @@
    "id": "cell-14",
    "metadata": {},
    "outputs": [],
-   "source": "# Clean up demo1 directory but keep slice for Demo 2\nmax_node.execute(f\"rm -rf {mount_path}/demo1\", quiet=True)\nslice1.delete()"
+   "source": "# Clean up demo1 directory but keep slice for Demo 2\nnode_a.execute(f\"rm -rf {mount_path}/demo1\", quiet=True)\nslice1.delete()"
   },
   {
    "cell_type": "markdown",
@@ -119,7 +119,7 @@
   {
    "cell_type": "code",
    "id": "yh2qcm6wac",
-   "source": "import datetime\n\n# Create first slice with storage\nslice2a = fablib.new_slice(name=\"CephFS-Persist-A\", storage=True)\nwriter = slice2a.add_node(name=\"writer\", site=\"MAX\", cores=4, ram=8, disk=50)\nslice2a.submit();",
+   "source": "import datetime\n\n[site1] = fablib.get_random_sites(count=1)\nprint(f\"Writer site: {site1}\")\n\n# Create first slice with storage\nslice2a = fablib.new_slice(name=\"CephFS-Persist-A\", storage=True)\nwriter = slice2a.add_node(name=\"writer\", site=site1, cores=4, ram=8, disk=50)\nslice2a.submit();",
    "metadata": {},
    "execution_count": null,
    "outputs": []
@@ -155,7 +155,7 @@
   {
    "cell_type": "code",
    "id": "03plof7ev2a1",
-   "source": "# Create a completely new slice — even at a different site!\nslice2b = fablib.new_slice(name=\"CephFS-Persist-B\", storage=True)\nreader = slice2b.add_node(name=\"reader\", site=\"UTAH\", cores=4, ram=8, disk=50)\nslice2b.submit();",
+   "source": "# Create a completely new slice — even at a different site!\n[site2] = fablib.get_random_sites(count=1, avoid=[site1])\nprint(f\"Reader site: {site2} (different from writer site {site1})\")\n\nslice2b = fablib.new_slice(name=\"CephFS-Persist-B\", storage=True)\nreader = slice2b.add_node(name=\"reader\", site=site2, cores=4, ram=8, disk=50)\nslice2b.submit();",
    "metadata": {},
    "execution_count": null,
    "outputs": []
@@ -191,7 +191,7 @@
   {
    "cell_type": "code",
    "id": "y6dph5ki3f",
-   "source": "# Node-level storage: only producer and consumer get CephFS\nslice3 = fablib.new_slice(name=\"CephFS-Pipeline\")\n\n# Producer generates data (needs CephFS)\nproducer = slice3.add_node(name=\"producer\", site=\"MAX\", cores=4, ram=8, disk=50, storage=True)\n\n# Consumer processes data (needs CephFS)\nconsumer = slice3.add_node(name=\"consumer\", site=\"UTAH\", cores=4, ram=8, disk=50, storage=True)\n\nslice3.submit();",
+   "source": "# Pick two random sites for the pipeline\n[site1, site2] = fablib.get_random_sites(count=2)\nprint(f\"Producer: {site1}, Consumer: {site2}\")\n\n# Node-level storage: only producer and consumer get CephFS\nslice3 = fablib.new_slice(name=\"CephFS-Pipeline\")\n\n# Producer generates data (needs CephFS)\nproducer = slice3.add_node(name=\"producer\", site=site1, cores=4, ram=8, disk=50, storage=True)\n\n# Consumer processes data (needs CephFS)\nconsumer = slice3.add_node(name=\"consumer\", site=site2, cores=4, ram=8, disk=50, storage=True)\n\nslice3.submit();",
    "metadata": {},
    "execution_count": null,
    "outputs": []
@@ -227,7 +227,7 @@
   {
    "cell_type": "markdown",
    "id": "kmlrerxsuym",
-   "source": "### Consumer: Process the dataset\n\nThe consumer at UTAH reads the producer's CSV directly from shared storage, computes per-sensor statistics, and writes the summary back — all without any file transfer.",
+   "source": "### Consumer: Process the dataset\n\nThe consumer reads the producer's CSV directly from shared storage, computes per-sensor statistics, and writes the summary back — all without any file transfer.",
    "metadata": {}
   },
   {
@@ -241,13 +241,13 @@
   {
    "cell_type": "markdown",
    "id": "b52o4p1fyzw",
-   "source": "### Producer sees the consumer's output\n\nBack at MAX, the producer can see the summary that the consumer at UTAH wrote — demonstrating bidirectional data flow through shared storage.",
+   "source": "### Producer sees the consumer's output\n\nThe producer can see the summary that the consumer wrote — demonstrating bidirectional data flow through shared storage.",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "id": "rqf7seoio5",
-   "source": "print(\"Producer at MAX can see the consumer's analysis:\")\nproducer.execute(f\"cat {mount_path}/pipeline/summary.csv\")\n\nprint(\"\\nFull pipeline directory on CephFS:\")\nproducer.execute(f\"ls -lh {mount_path}/pipeline/\")",
+   "source": "print(\"Producer can see the consumer's analysis:\")\nproducer.execute(f\"cat {mount_path}/pipeline/summary.csv\")\n\nprint(\"\\nFull pipeline directory on CephFS:\")\nproducer.execute(f\"ls -lh {mount_path}/pipeline/\")",
    "metadata": {},
    "execution_count": null,
    "outputs": []

--- a/fabric_examples/fablib_api/cephfs_storage/cephfs_storage_basic.ipynb
+++ b/fabric_examples/fablib_api/cephfs_storage/cephfs_storage_basic.ipynb
@@ -39,7 +39,7 @@
    "id": "cell-create",
    "metadata": {},
    "outputs": [],
-   "source": "SLICE_NAME = \"CephFS-QuickStart\"\nSITE = \"MAX\"\n\nslice1 = fablib.new_slice(name=SLICE_NAME, storage=True)\nnode1 = slice1.add_node(name=\"node1\", site=SITE, cores=4, ram=8, disk=50)\nnode2 = slice1.add_node(name=\"node2\", site=SITE, cores=4, ram=8, disk=50)\nslice1.submit();"
+   "source": "SLICE_NAME = \"CephFS-QuickStart\"\n\n[site1, site2] = fablib.get_random_sites(count=2)\nprint(f\"Using sites: {site1}, {site2}\")\n\nslice1 = fablib.new_slice(name=SLICE_NAME, storage=True)\nnode1 = slice1.add_node(name=\"node1\", site=site1, cores=4, ram=8, disk=50)\nnode2 = slice1.add_node(name=\"node2\", site=site2, cores=4, ram=8, disk=50)\nslice1.submit();"
   },
   {
    "cell_type": "markdown",
@@ -92,7 +92,7 @@
   {
    "cell_type": "code",
    "id": "bwsrzcskr9w",
-   "source": "SLICE_NAME_2 = \"CephFS-NodeLevel\"\n\nslice2 = fablib.new_slice(name=SLICE_NAME_2)\n\n# Only this node gets shared storage\nstorage_node = slice2.add_node(name=\"with-storage\", site=\"MAX\", cores=4, ram=8, disk=50, storage=True)\n\n# This node does NOT get shared storage\ncompute_node = slice2.add_node(name=\"compute-only\", site=\"MAX\", cores=4, ram=8, disk=50)\n\nslice2.submit();",
+   "source": "SLICE_NAME_2 = \"CephFS-NodeLevel\"\n\n[site1, site2] = fablib.get_random_sites(count=2)\nprint(f\"Using sites: {site1}, {site2}\")\n\nslice2 = fablib.new_slice(name=SLICE_NAME_2)\n\n# Only this node gets shared storage\nstorage_node = slice2.add_node(name=\"with-storage\", site=site1, cores=4, ram=8, disk=50, storage=True)\n\n# This node does NOT get shared storage\ncompute_node = slice2.add_node(name=\"compute-only\", site=site2, cores=4, ram=8, disk=50)\n\nslice2.submit();",
    "metadata": {},
    "execution_count": null,
    "outputs": []


### PR DESCRIPTION
## Summary
- Replace hardcoded `MAX`/`UTAH` site names with `fablib.get_random_sites()` in both `cephfs_storage_basic.ipynb` and `cephfs_storage.ipynb`
- Basic notebook now places both nodes on **separate sites** to demonstrate cross-site shared storage
- Advanced notebook shows `discover_user_ceph_clusters()` alongside `discover_ceph_clusters()`
- All demo slices (multi-site, persistence, pipeline) use dynamically selected sites

## Test plan
- [x] Run `cephfs_storage_basic.ipynb` end-to-end — verify sites are randomly selected and storage mounts work
- [x] Run `cephfs_storage.ipynb` Demo 1, 2, 3 — verify cross-site data sharing with random sites
- [x] Verify `discover_user_ceph_clusters()` returns correct subset of clusters